### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ Each time you change the library or compiler, you'll need to publish both the co
 
 Catching a regression typically does not require deep knowledge of the workings
 of scala-collection-laws.  Simply change the target version of Scala in the
-`tests/build.sbt` file (and in `laws/build.sbt` if the change is not binary
-compatible with the version already in `laws/build.sbt`) and use `run.sh` again.
+`build.sbt` file and use `run.sh` again.
 
 #### Regression class 1: expected relationship fails.
 


### PR DESCRIPTION
There is neither a version in `tests/build.sbt` nor is there a `laws/build.sbt`.
Version is `build.sbt` since 047377362830774e0ffa7dc790c6cd1c68a85857. (One of the nicer hashes, starting with a long octal literal :ok_hand: )