### PR TITLE
add explicit type

### DIFF
--- a/laws/src/main/scala/Test.scala
+++ b/laws/src/main/scala/Test.scala
@@ -94,9 +94,9 @@ with TestInfo {
 
   def inst: Instance[_, _] = instance
 
-  protected def boxedRuntime = a.getClass
+  protected def boxedRuntime: Class[_] = a.getClass
 
-  def runtimeColl = x.getClass
+  def runtimeColl: Class[_] = x.getClass
 
   def name = nm.value.toString
 


### PR DESCRIPTION
prepare Scala 2.13.12

- https://github.com/scala/scala/pull/10439
- https://github.com/scala/community-build/blob/12866dc60bf80ea569f8a7e4d229a8afe04d84a1/proj/scala-collection-laws.conf#L10-L11

```
[error] laws/src/main/scala/Test.scala:97:17: under -Xsource:3, inferred Class[_] instead of Class[_ <: A] [quickfixable]
[error] Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=laws.Test.boxedRuntime
[error]   protected def boxedRuntime = a.getClass
[error]                 ^
[error] laws/src/main/scala/Test.scala:99:7: under -Xsource:3, inferred Class[_] instead of Class[_ <: CC] [quickfixable]
[error] Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=laws.Test.runtimeColl
[error]   def runtimeColl = x.getClass
[error]       ^
[error] two errors found
[error] (laws / Compile / compileIncremental) Compilation failed
```